### PR TITLE
Allow empty path, as stated by rfc3986 section-3.3

### DIFF
--- a/lib/ex_link_header.ex
+++ b/lib/ex_link_header.ex
@@ -121,7 +121,6 @@ defmodule ExLinkHeader do
     case URI.parse(url) do
       %URI{host: nil} -> false
       %URI{scheme: nil} -> false
-      %URI{path: nil} -> false
       _ -> true
     end
   end

--- a/test/ex_link_header_test.exs
+++ b/test/ex_link_header_test.exs
@@ -204,6 +204,22 @@ defmodule ExLinkHeaderTest do
 
   end
 
+  test "parsing a header with no path, arbitrary params and no defaults" do
+    link_header =
+      "<https://api.example.com?q=elixir&sort=stars&order=desc>; rel=\"last\""
+
+    assert ExLinkHeader.parse!(link_header) ==
+      %{"last" => %{
+          url: "https://api.example.com?q=elixir&sort=stars&order=desc",
+          q: "elixir",
+          sort: "stars",
+          order: "desc",
+          rel: "last"
+        }
+      }
+
+  end
+
   test "parsing an empty or invalid link header raises" do
     assert_raise ParseError, fn -> ExLinkHeader.parse!("") end
     assert_raise ParseError, fn -> ExLinkHeader.parse!("nonsense") end


### PR DESCRIPTION
rfc3986, section-3.3 allows empty path 

> A path is always defined for a URI, though the
>    defined path may be empty (zero length)

this small fix takes in account the scenario
